### PR TITLE
feat(frontend): remove SVG-scroll animation and fixed-height scaffolding from product-listing pages

### DIFF
--- a/src/pages/ProductListing.jsx
+++ b/src/pages/ProductListing.jsx
@@ -1,203 +1,124 @@
-import OurGlobalPresence from "@/sections/OurGlobalPresence";
-import ProductListingCards from '@/sections/ProductListingCards';
-import  React, { useEffect, useRef, useState } from "react";
-import { useLocation } from 'react-router-dom';
-import Loader from "../pages/Loader";
+import React, { useEffect, useState } from "react";
+import ProductListingCards from "@/sections/ProductListingCards";
 import Footer from "@/components/Footer";
+// import OurGlobalPresence from "@/sections/OurGlobalPresence";
 
-const ProductListing = ({language}) => {
-  const [categories, setCategories] = useState([]); // Initialize categories state
-  const [products, setProducts] = useState([]);
+const ProductListing = ({ language = "en" }) => {
+  /* ────────────────────────────
+     1. STATE
+  ──────────────────────────── */
+  const [categories, setCategories] = useState([]);
   const [pageContent, setPageContent] = useState({
     sectionTitle: "Industrial Applications",
-    mainHeading: "Home, Personal Care & Cosmetics"
+    mainHeading: "Home, Personal Care & Cosmetics",
   });
-  
+
+  /* ────────────────────────────
+     2. DATA FETCHING
+  ──────────────────────────── */
   useEffect(() => {
+    /* Categories + products */
     const fetchCategories = async () => {
       try {
-        const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ targetLanguage: language }) // Add language to request
-        });
-        const data = await response.json();
-  
-          if (!Array.isArray(data)) {
-              throw new Error("Invalid data format");
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ targetLanguage: language }),
           }
-  
-          const formattedCategories = data.map(edge => {
-              const fields = edge.node.fields;
-              const categoryName = fields.find(field => field.key === 'category_name')?.value;
-              const products = fields.find(field => field.key === 'products')?.references?.edges.map(productEdge => productEdge.node) || [];
-  
-              return { categoryName, products };
-          });
-  
-          setCategories(formattedCategories);
-      } catch (error) {
-          console.error('Error fetching categories:', error);
-      }
-    };  
+        );
+        const data = await res.json();
+        if (!Array.isArray(data)) throw new Error("Invalid data");
 
-    // Fetch static content translations
-    const fetchPageContent = async () => {
-      try {
-        const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/translate-content`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            content: {
-              sectionTitle: "Industrial Applications",
-              mainHeading: "Home, Personal Care & Cosmetics"
-            },
-            targetLanguage: language
-          })
+        const formatted = data.map((edge) => {
+          const fields = edge.node.fields;
+          const products =
+            fields
+              .find((f) => f.key === "products")
+              ?.references?.edges.map((e) => e.node) || [];
+          return { products };
         });
-        const translatedContent = await response.json();
-        setPageContent(translatedContent);
-      } catch (error) {
-        console.error('Error fetching translations:', error);
+
+        setCategories(formatted);
+      } catch (err) {
+        console.error("Category fetch error:", err);
+      }
+    };
+
+    /* Static copy (translate if non-EN) */
+    const fetchStaticCopy = async () => {
+      if (language === "en") return;
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/translate-content`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              content: {
+                sectionTitle: "Industrial Applications",
+                mainHeading: "Home, Personal Care & Cosmetics",
+              },
+              targetLanguage: language,
+            }),
+          }
+        );
+        const translated = await res.json();
+        setPageContent(translated);
+      } catch (err) {
+        console.error("Translation fetch error:", err);
       }
     };
 
     fetchCategories();
-    if (language !== 'en') {
-      fetchPageContent();
-    }
+    fetchStaticCopy();
   }, [language]);
 
-  const [svgContent, setSvgContent] = useState(""); // State to hold SVG content
-  const svgContainerRef = useRef(null);
-  const scrollContainerRef = useRef(null);
-  const pathRef = useRef(null);
-
-  useEffect(() => {
-    // if (!metaFields) return; // Ensure animation doesn't run until metaFields are set
-
-    const path = pathRef.current;
-    if (!path) return;
-
-    const pathLength = path.getTotalLength(); // Get the total length of the path
-
-    const handleOffset = (mPercent) => {
-      const distance = window.scrollY;
-      const totalDistance = document.body.scrollHeight - window.innerHeight;
-      const percentage = typeof mPercent === "number" ? mPercent : distance / totalDistance;
-
-      // Clamp percentage value to ensure it doesn't exceed [0, 1] range
-      const clampedPercentage = Math.min(Math.max(percentage, 0), 1);
-
-      // Update the strokeDasharray and strokeDashoffset values
-      const offset = pathLength - (pathLength * clampedPercentage * 0.5); // Adjust for desired speed
-
-      path.style.strokeDasharray = pathLength;
-      path.style.strokeDashoffset = offset;
-    };
-
-    window.addEventListener("scroll", () => handleOffset());
-    
-    // Trigger initially
-    handleOffset(0);
-
-    return () => {
-      window.removeEventListener("scroll", () => handleOffset());
-    };
-  }, []); // Run this effect only when `metaFields` is set
-
-  // width="1800" height="4026" viewBox="250 0 1900 5800"
-  const [viewBox, setViewBox] = useState("250 0 1900 5800");
-  const [width, setWidth] = useState("1800");
-  const [height, setHeight] = useState("4026");
-
-  useEffect(() => {
-    const updateSVGSize = () => {
-        if (window.innerWidth <= 768) {
-          setViewBox("450 0 900 2990");
-          setWidth("900");
-          setHeight("4600");
-        } else {
-            setViewBox("250 0 1900 5800");
-            setWidth("1800");
-            setHeight("4026");
-        }
-    };
-
-    updateSVGSize(); // Initial check
-    window.addEventListener('resize', updateSVGSize);
-
-    return () => window.removeEventListener('resize', updateSVGSize);
-  }, []);
-
+  /* ────────────────────────────
+     3. RENDER
+  ──────────────────────────── */
   return (
-    <div className="scrollContainer w-full lg:h-[3070px] h-[4600px] md:h-[4200px] overflow-hidden bg-no-repeat" ref={svgContainerRef}>
-      <svg 
-        width={width}
-        height={height}
-        viewBox={viewBox}
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg">
-          <path 
-            strokeOpacity="0.55"
-            strokeWidth="21"
-            speed="2"
-            stay=".7"
-            className="scrollPath cls-3"
-            style={{ strokeDasharray: "80000", zIndex: 5 }}
-            ref={pathRef}
-            stroke-width="80"          
-          d="M445.634 0.836114C454.975 -1.82847 462.56 2.21838 469.367 8.13043C488.641 24.884 511.766 69.8656 532.391 93.0475C808.928 403.971 1393.2 266.645 1760.87 255.937C1957.97 250.208 2318.88 285.83 2398.03 500.613C2406.61 523.911 2419.87 566.328 2410.06 589.326C2407.31 595.771 2399.84 599.652 2398.47 606.929C2397.1 614.207 2401.51 621.118 2401.51 628.562C2401.53 654.226 2360.77 702.521 2341.34 719.775C2184.33 859.232 1792.34 817.831 1592.58 812.286C1380.58 806.39 1169.45 800.978 956.952 796.565C710.279 791.435 294.654 755.18 117.475 962.668C-11.1398 1113.28 134.097 1314.31 285.465 1378.99C826.614 1610.25 1464.22 1200.98 2032.37 1356.91C2271.61 1422.56 2502.59 1627.33 2418.27 1895.62C2349.03 2115.92 2079.59 2213.46 1870.2 2250.3C1528.13 2310.47 1181.17 2264.73 837.306 2260.74C654.671 2258.61 378.337 2262.02 234.131 2385.51C78.438 2518.84 193.995 2674.38 343.86 2741.06C576.428 2844.55 976.073 2806.36 1232.76 2801.4C1489.45 2796.44 1899.47 2756.93 2141.8 2857.32C2448.08 2984.21 2356.99 3259.64 2114.91 3396.55C1545.75 3718.43 613.894 3033.77 132.205 3621.51C41.5291 3732.16 30.3467 3842.82 69.671 3977.2C141.546 4222.79 450.178 4339 679.908 4388.86C1123.1 4485.07 1685.04 4433.97 2044.71 4743.7C2104.27 4794.99 2165.43 4866.4 2185.63 4943.61C2191.21 4964.89 2204.38 5017.33 2174.44 5025.38C2143.46 5033.71 2136.19 4956.02 2129.06 4935.47C2068.27 4760.15 1824.82 4643.28 1657.34 4591.8C1240.99 4463.85 771.056 4519.94 369.789 4336.63C116.546 4220.94 -85.5317 3988.7 36.5798 3699.86C161.833 3403.65 512.729 3315.31 811.343 3325.52C1212.8 3339.23 1754.55 3559.52 2122.15 3339.78C2188.3 3300.24 2217.76 3276.09 2253.78 3207.42C2392.19 2943.5 2080.01 2861.6 1880.89 2846.06C1522.9 2818.1 1162.69 2855.54 804.84 2855.76C593.995 2855.89 254.924 2836.37 139.198 2629.57C12.8129 2403.71 302.83 2262.97 484.739 2233.04C810.347 2179.45 1163.93 2251.18 1495.31 2241.84C1754.18 2234.54 2212.41 2191.88 2354.27 1944.4C2472.83 1737.56 2354.01 1568.78 2170.8 1463.38C1858.02 1283.45 1393.61 1404.67 1056.55 1460.51C743.387 1512.41 315.161 1552.76 95.0933 1275.79C11.7318 1170.87 -19.9067 1071.12 64.6204 952.11C232.12 716.277 689.924 738.477 947.492 745.155C1247.69 752.932 1548.2 771.701 1848.66 773.932C1986.88 774.965 2237.93 777.746 2333.07 660.488C2340.04 651.894 2366.63 610.693 2368.22 602.183C2369.54 595.139 2363.4 552.622 2361.48 543.079C2333.61 404.904 2155.25 344.001 2031.73 321.552C1547 233.504 862.644 532.338 486.985 112.232C471.884 95.3457 428.928 42.7367 430.381 21.2368C430.82 14.692 439.249 2.63474 445.6 0.819495L445.634 0.836114Z" 
-          fill="url(#paint0_angular_2834_3931)
-          "/>
-      <defs>
-      <radialGradient id="paint0_angular_2834_3931" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1218.59 2337.99) rotate(-90) scale(2962 3004.37)">
-      <stop offset="0.06" stop-color="#9D2924"/>
-      <stop offset="0.265" stop-color="#EA5C50"/>
-      <stop offset="0.515" stop-color="#E4A16B"/>
-      <stop offset="0.76" stop-color="#80B2BD"/>
-      <stop offset="0.96" stop-color="#D88BD3"/>
-      </radialGradient>
-      </defs>
-      </svg>
-      <div className="absolute w-full h-full top-[0] z-10 ">
-        <div className='w-full bg-cover bg-center relative'>
-          <div className='h-[50vh] sm:h-[50vh] md:h-[60vh] lg:h-[80dvh] w-full bg-cover bg-center relative '>
-            <img 
-              src="/images/productListing.png" 
-              className='hidden sm:hidden md:block w-full h-[65dvh] object-cover' 
-              alt="Large Image"
-            />
-            <img 
-              src="/images/productListingSmall.png" 
-              className='block sm:block md:hidden w-full h-full object-cover' 
-              alt="Small Image"
-            />
+    <div className="w-full relative min-h-screen bg-white">
+      {/* ── HERO BANNER ───────────────────────── */}
+      <div className="h-[50vh] md:h-[60vh] lg:h-[80dvh] relative w-full">
+        {/* Desktop banner */}
+        <img
+          src="/images/productListing.png"
+          alt="Product banner"
+          className="hidden md:block w-full h-[65dvh] object-cover"
+        />
+        {/* Mobile banner */}
+        <img
+          src="/images/productListingSmall.png"
+          alt="Product banner mobile"
+          className="block md:hidden w-full h-full object-cover"
+        />
 
-            <div className='absolute inset-3 flex flex-col gap-3 sm:gap-4 md:gap-5 lg:gap-6 justify-center text-white font-medium p-5 xl:p-10 -mb-40 sm:-mb-44 md:-mb-64 lg:-mb-16'>
-              <p className="text-[12px] sm:text-[14px] md:text-[15px] lg:text-[16px] font-normal">{pageContent.sectionTitle}</p>
-              <h1 className='w-full md:w-[500px] lg:w-[650px] text-[40px] sm:text-[32px] md:text-[40px] lg:text-[56px] leading-[45px] sm:leading-10 md:leading-10 lg:leading-[65px] font-heading'>
-                {pageContent.mainHeading}
-              </h1>
-            </div>
-          </div>
-          
-          <div className="bg-white">
-            {categories.map((category, index) => (
-              <div key={index}>
-                {/* <h2>{category.categoryName}</h2> */}
-                <ProductListingCards products={category.products} language={language}/>
-              </div>
-            ))}
-          </div>
-          {/* <OurGlobalPresence language={language} /> */}
-          <Footer language={language} />
+        <div className="absolute inset-4 md:inset-6 lg:inset-10 flex flex-col justify-center gap-4 md:gap-5 lg:gap-6 text-white">
+          <p className="text-xs md:text-sm lg:text-base font-normal">
+            {pageContent.sectionTitle}
+          </p>
+          <h1 className="font-heading text-3xl md:text-4xl lg:text-5xl leading-tight lg:leading-[65px] max-w-[650px]">
+            {pageContent.mainHeading}
+          </h1>
         </div>
-      </div>      
+      </div>
+
+      {/* ── PRODUCT LIST ───────────────────────── */}
+      <div className="bg-white">
+        {categories.map((cat, idx) => (
+          <div key={idx}>
+            <ProductListingCards products={cat.products} language={language} />
+          </div>
+        ))}
+      </div>
+
+      {/* ── OPTIONAL GLOBAL PRESENCE ───────────── */}
+      {/* <OurGlobalPresence language={language} /> */}
+
+      {/* ── FOOTER ─────────────────────────────── */}
+      <Footer language={language} />
     </div>
   );
 };

--- a/src/pages/ProductListing2.jsx
+++ b/src/pages/ProductListing2.jsx
@@ -1,204 +1,124 @@
-import OurGlobalPresence from "@/sections/OurGlobalPresence";
-import ProductListingCards2 from '@/sections/ProductListingCards2';
-import  React, { useEffect, useRef, useState } from "react";
-import { useLocation } from 'react-router-dom';
-import Loader from "../pages/Loader";
+import React, { useEffect, useState } from "react";
+import ProductListingCards2 from "@/sections/ProductListingCards2";
 import Footer from "@/components/Footer";
+// import OurGlobalPresence from "@/sections/OurGlobalPresence";
 
-const ProductListing2 = ({language}) => {
-  const [categories, setCategories] = useState([]); // Initialize categories state
-  const [products, setProducts] = useState([]);
+const ProductListing2 = ({ language = "en" }) => {
+  /* ────────────────────────────
+     1. STATE
+  ──────────────────────────── */
+  const [categories, setCategories] = useState([]);
   const [pageContent, setPageContent] = useState({
     sectionTitle: "Industrial Applications",
-    mainHeading: "Life Sciences"
+    mainHeading: "Life Sciences",
   });
-  
+
+  /* ────────────────────────────
+     2. DATA FETCHING
+  ──────────────────────────── */
   useEffect(() => {
+    /* Fetch category + product cards */
     const fetchCategories = async () => {
       try {
-        const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ targetLanguage: language }) // Add language to request
-        });
-        const data = await response.json();
-  
-          if (!Array.isArray(data)) {
-              throw new Error("Invalid data format");
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ targetLanguage: language }),
           }
-  
-          const formattedCategories = data.map(edge => {
-              const fields = edge.node.fields;
-              const categoryName = fields.find(field => field.key === 'category_name_2')?.value;
-              const products = fields.find(field => field.key === 'products_2')?.references?.edges.map(productEdge => productEdge.node) || [];
-  
-              return { categoryName, products };
-          });
-  
-          setCategories(formattedCategories);
-      } catch (error) {
-          console.error('Error fetching categories:', error);
-      }
-    };  
+        );
+        const data = await res.json();
+        if (!Array.isArray(data)) throw new Error("Invalid data");
 
-    // Fetch static content translations
-    const fetchPageContent = async () => {
-      try {
-        const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/translate-content`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            content: {
-              sectionTitle: "Industrial Applications",
-              mainHeading: "Life Sciences"
-            },
-            targetLanguage: language
-          })
+        const formatted = data.map((edge) => {
+          const fields = edge.node.fields;
+          const products =
+            fields
+              .find((f) => f.key === "products_2")
+              ?.references?.edges.map((e) => e.node) || [];
+          return { products };
         });
-        const translatedContent = await response.json();
-        setPageContent(translatedContent);
-      } catch (error) {
-        console.error('Error fetching translations:', error);
+
+        setCategories(formatted);
+      } catch (err) {
+        console.error("Category fetch error:", err);
+      }
+    };
+
+    /* Translate static copy if needed */
+    const fetchStaticCopy = async () => {
+      if (language === "en") return;
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/translate-content`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              content: {
+                sectionTitle: "Industrial Applications",
+                mainHeading: "Life Sciences",
+              },
+              targetLanguage: language,
+            }),
+          }
+        );
+        const translated = await res.json();
+        setPageContent(translated);
+      } catch (err) {
+        console.error("Translation fetch error:", err);
       }
     };
 
     fetchCategories();
-    if (language !== 'en') {
-      fetchPageContent();
-    }
+    fetchStaticCopy();
   }, [language]);
 
-  const [svgContent, setSvgContent] = useState(""); // State to hold SVG content
-  const svgContainerRef = useRef(null);
-  const scrollContainerRef = useRef(null);
-  const pathRef = useRef(null);
-
-  useEffect(() => {
-    // if (!metaFields) return; // Ensure animation doesn't run until metaFields are set
-
-    const path = pathRef.current;
-    if (!path) return;
-
-    const pathLength = path.getTotalLength(); // Get the total length of the path
-
-    const handleOffset = (mPercent) => {
-      const distance = window.scrollY;
-      const totalDistance = document.body.scrollHeight - window.innerHeight;
-      const percentage = typeof mPercent === "number" ? mPercent : distance / totalDistance;
-
-      // Clamp percentage value to ensure it doesn't exceed [0, 1] range
-      const clampedPercentage = Math.min(Math.max(percentage, 0), 1);
-
-      // Update the strokeDasharray and strokeDashoffset values
-      const offset = pathLength - (pathLength * clampedPercentage * 0.3); // Adjust for desired speed
-
-      path.style.strokeDasharray = pathLength;
-      path.style.strokeDashoffset = offset;
-    };
-
-    window.addEventListener("scroll", () => handleOffset());
-    
-    // Trigger initially
-    handleOffset(0);
-
-    return () => {
-      window.removeEventListener("scroll", () => handleOffset());
-    };
-  }, []); // Run this effect only when `metaFields` is set
-
-  // width="2436" height="4426" viewBox="250 0 2500 4500"
-  const [viewBox, setViewBox] = useState("250 0 2500 4500");
-  const [width, setWidth] = useState("2436");
-  const [height, setHeight] = useState("4426");
-
-  useEffect(() => {
-    const updateSVGSize = () => {
-        if (window.innerWidth <= 768) {
-          setViewBox("750 0 1500 1500");
-          setWidth("1436");
-          setHeight("2950");
-        } else {
-            setViewBox("250 0 2500 4500");
-            setWidth("2436");
-            setHeight("4426");
-        }
-    };
-
-    updateSVGSize(); // Initial check
-    window.addEventListener('resize', updateSVGSize);
-
-    return () => window.removeEventListener('resize', updateSVGSize);
-  }, []);
-
+  /* ────────────────────────────
+     3. RENDER
+  ──────────────────────────── */
   return (
-    <div className="scrollContainer w-full lg:h-[2530px] overflow-hidden bg-no-repeat" ref={svgContainerRef}>
-      <svg 
-        width={width}
-        height={height}
-        viewBox={viewBox}
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg">
-          <path 
-            strokeOpacity="0.55"
-            strokeWidth="21"
-            speed="2"
-            stay=".7"
-            className="scrollPath cls-3"
-            style={{ strokeDasharray: "80000", zIndex: 5 }}
-            ref={pathRef}
-            stroke-width="80"          
-          d="M445.634 0.836114C454.975 -1.82847 462.56 2.21838 469.367 8.13043C488.641 24.884 511.766 69.8656 532.391 93.0475C808.928 403.971 1393.2 266.645 1760.87 255.937C1957.97 250.208 2318.88 285.83 2398.03 500.613C2406.61 523.911 2419.87 566.328 2410.06 589.326C2407.31 595.771 2399.84 599.652 2398.47 606.929C2397.1 614.207 2401.51 621.118 2401.51 628.562C2401.53 654.226 2360.77 702.521 2341.34 719.775C2184.33 859.232 1792.34 817.831 1592.58 812.286C1380.58 806.39 1169.45 800.978 956.952 796.565C710.279 791.435 294.654 755.18 117.475 962.668C-11.1398 1113.28 134.097 1314.31 285.465 1378.99C826.614 1610.25 1464.22 1200.98 2032.37 1356.91C2271.61 1422.56 2502.59 1627.33 2418.27 1895.62C2349.03 2115.92 2079.59 2213.46 1870.2 2250.3C1528.13 2310.47 1181.17 2264.73 837.306 2260.74C654.671 2258.61 378.337 2262.02 234.131 2385.51C78.438 2518.84 193.995 2674.38 343.86 2741.06C576.428 2844.55 976.073 2806.36 1232.76 2801.4C1489.45 2796.44 1899.47 2756.93 2141.8 2857.32C2448.08 2984.21 2356.99 3259.64 2114.91 3396.55C1545.75 3718.43 613.894 3033.77 132.205 3621.51C41.5291 3732.16 30.3467 3842.82 69.671 3977.2C141.546 4222.79 450.178 4339 679.908 4388.86C1123.1 4485.07 1685.04 4433.97 2044.71 4743.7C2104.27 4794.99 2165.43 4866.4 2185.63 4943.61C2191.21 4964.89 2204.38 5017.33 2174.44 5025.38C2143.46 5033.71 2136.19 4956.02 2129.06 4935.47C2068.27 4760.15 1824.82 4643.28 1657.34 4591.8C1240.99 4463.85 771.056 4519.94 369.789 4336.63C116.546 4220.94 -85.5317 3988.7 36.5798 3699.86C161.833 3403.65 512.729 3315.31 811.343 3325.52C1212.8 3339.23 1754.55 3559.52 2122.15 3339.78C2188.3 3300.24 2217.76 3276.09 2253.78 3207.42C2392.19 2943.5 2080.01 2861.6 1880.89 2846.06C1522.9 2818.1 1162.69 2855.54 804.84 2855.76C593.995 2855.89 254.924 2836.37 139.198 2629.57C12.8129 2403.71 302.83 2262.97 484.739 2233.04C810.347 2179.45 1163.93 2251.18 1495.31 2241.84C1754.18 2234.54 2212.41 2191.88 2354.27 1944.4C2472.83 1737.56 2354.01 1568.78 2170.8 1463.38C1858.02 1283.45 1393.61 1404.67 1056.55 1460.51C743.387 1512.41 315.161 1552.76 95.0933 1275.79C11.7318 1170.87 -19.9067 1071.12 64.6204 952.11C232.12 716.277 689.924 738.477 947.492 745.155C1247.69 752.932 1548.2 771.701 1848.66 773.932C1986.88 774.965 2237.93 777.746 2333.07 660.488C2340.04 651.894 2366.63 610.693 2368.22 602.183C2369.54 595.139 2363.4 552.622 2361.48 543.079C2333.61 404.904 2155.25 344.001 2031.73 321.552C1547 233.504 862.644 532.338 486.985 112.232C471.884 95.3457 428.928 42.7367 430.381 21.2368C430.82 14.692 439.249 2.63474 445.6 0.819495L445.634 0.836114Z" 
-          fill="url(#paint0_angular_2834_3931)
-          "/>
-      <defs>
-      <radialGradient id="paint0_angular_2834_3931" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1218.59 2337.99) rotate(-90) scale(2962 3004.37)">
-      <stop offset="0.06" stop-color="#9D2924"/>
-      <stop offset="0.265" stop-color="#EA5C50"/>
-      <stop offset="0.515" stop-color="#E4A16B"/>
-      <stop offset="0.76" stop-color="#80B2BD"/>
-      <stop offset="0.96" stop-color="#D88BD3"/>
-      </radialGradient>
-      </defs>
-      </svg>
-      <div className="absolute w-full h-full top-[0] z-10 ">
-        <div className='w-full bg-cover bg-center relative'>
-          <div className='h-[50vh] sm:h-[50vh] md:h-[60vh] lg:h-[80dvh] w-full bg-cover bg-center relative'>
-            <img 
-              src="/images/productListing.png" 
-              className='hidden sm:hidden md:block w-full h-[65dvh] object-cover' 
-              alt="Large Image"
-            />
-            <img 
-              src="/images/productListingSmall.png" 
-              className='block sm:block md:hidden w-full h-full object-cover' 
-              alt="Small Image"
-            />
+    <div className="w-full relative min-h-screen bg-white">
+      {/* ── HERO BANNER ───────────────────────── */}
+      <div className="h-[50vh] md:h-[60vh] lg:h-[80dvh] relative w-full">
+        {/* Desktop */}
+        <img
+          src="/images/productListing.png"
+          alt="Product banner"
+          className="hidden md:block w-full h-[65dvh] object-cover"
+        />
+        {/* Mobile */}
+        <img
+          src="/images/productListingSmall.png"
+          alt="Product banner mobile"
+          className="block md:hidden w-full h-full object-cover"
+        />
 
-            <div className='absolute inset-3 flex flex-col gap-3 sm:gap-4 md:gap-5 lg:gap-6 justify-center text-white font-medium p-5 xl:p-10 -mb-40 sm:-mb-44 md:-mb-64 lg:-mb-16'>
-              <p className="text-[12px] sm:text-[14px] md:text-[15px] lg:text-[16px] font-normal">{pageContent.sectionTitle}</p>
-              <h1 className='w-full md:w-[500px] lg:w-[650px] text-[40px] sm:text-[32px] md:text-[40px] lg:text-[56px] leading-[45px] sm:leading-10 md:leading-10 lg:leading-[65px] font-heading'>
-                {pageContent.mainHeading}
-              </h1>
-            </div>
-          </div>
-          
-          <div className="bg-white">
-            {categories.map((category, index) => (
-              <div key={index}>
-                {/* <h2>{category.categoryName}</h2> */}
-                <ProductListingCards2 products={category.products} language={language}/>
-              </div>
-            ))}
-          </div>
-          <br />
-          {/* <OurGlobalPresence language={language} /> */}
-          <Footer language={language} />
+        <div className="absolute inset-4 md:inset-6 lg:inset-10 flex flex-col justify-center gap-4 md:gap-5 lg:gap-6 text-white">
+          <p className="text-xs md:text-sm lg:text-base font-normal">
+            {pageContent.sectionTitle}
+          </p>
+          <h1 className="font-heading text-3xl md:text-4xl lg:text-5xl leading-tight lg:leading-[65px] max-w-[650px]">
+            {pageContent.mainHeading}
+          </h1>
         </div>
-      </div>      
+      </div>
+
+      {/* ── PRODUCT LIST GRID ─────────────────── */}
+      <div className="bg-white">
+        {categories.map((cat, idx) => (
+          <div key={idx}>
+            <ProductListingCards2 products={cat.products} language={language} />
+          </div>
+        ))}
+      </div>
+
+      {/* ── OPTIONAL GLOBAL PRESENCE ───────────── */}
+      {/* <OurGlobalPresence language={language} /> */}
+
+      {/* ── FOOTER ─────────────────────────────── */}
+      {/* <Footer language={language} /> */}
     </div>
   );
 };

--- a/src/pages/ProductListing3.jsx
+++ b/src/pages/ProductListing3.jsx
@@ -1,204 +1,125 @@
-import OurGlobalPresence from "@/sections/OurGlobalPresence";
-import ProductListingCards3 from '@/sections/ProductListingCards3';
-import  React, { useEffect, useRef, useState } from "react";
-import { useLocation } from 'react-router-dom';
-import Loader from "../pages/Loader";
+import React, { useEffect, useState } from "react";
+import ProductListingCards3 from "@/sections/ProductListingCards3";
+import Footer from "@/components/Footer";
+// import OurGlobalPresence from "@/sections/OurGlobalPresence";
 
-const ProductListing3 = ({language}) => {
-  const [categories, setCategories] = useState([]); // Initialize categories state
-  const [products, setProducts] = useState([]);
+const ProductListing3 = ({ language = "en" }) => {
+  /* ────────────────────────────
+     1. STATE
+  ──────────────────────────── */
+  const [categories, setCategories] = useState([]);
   const [pageContent, setPageContent] = useState({
     sectionTitle: "Industrial Applications",
-    mainHeading: "Coatings & Inks"
+    mainHeading: "Coatings & Inks",
   });
-  
+
+  /* ────────────────────────────
+     2. DATA FETCHING
+  ──────────────────────────── */
   useEffect(() => {
+    /* Categories + products */
     const fetchCategories = async () => {
       try {
-          const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ targetLanguage: language }) // Add language to request
-          });
-          const data = await response.json();
-  
-          if (!Array.isArray(data)) {
-              throw new Error("Invalid data format");
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/fetchProductCategories`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ targetLanguage: language }),
           }
-  
-          const formattedCategories = data.map(edge => {
-              const fields = edge.node.fields;
-              const categoryName = fields.find(field => field.key === 'category_name_3')?.value;
-              const products = fields.find(field => field.key === 'products_3')?.references?.edges.map(productEdge => productEdge.node) || [];
-  
-              return { categoryName, products };
-          });
-  
-          setCategories(formattedCategories);
-          
-      } catch (error) {
-          console.error('Error fetching categories:', error);
-      }
-    };  
+        );
+        const data = await res.json();
+        if (!Array.isArray(data)) throw new Error("Invalid data");
 
-    // Fetch static content translations
-    const fetchPageContent = async () => {
-      try {
-        const response = await fetch(`${import.meta.env.VITE_BASE_URL}/shopify/translate-content`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            content: {
-              sectionTitle: "Industrial Applications",
-              mainHeading: "Coatings & Inks"
-            },
-            targetLanguage: language
-          })
+        const formatted = data.map((edge) => {
+          const fields = edge.node.fields;
+          const products =
+            fields
+              .find((f) => f.key === "products_3")
+              ?.references?.edges.map((e) => e.node) || [];
+          return { products };
         });
-        const translatedContent = await response.json();
-        setPageContent(translatedContent);
-      } catch (error) {
-        console.error('Error fetching translations:', error);
+
+        setCategories(formatted);
+      } catch (err) {
+        console.error("Category fetch error:", err);
+      }
+    };
+
+    /* Static copy (translate if non-EN) */
+    const fetchStaticCopy = async () => {
+      if (language === "en") return;
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_BASE_URL}/shopify/translate-content`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              content: {
+                sectionTitle: "Industrial Applications",
+                mainHeading: "Coatings & Inks",
+              },
+              targetLanguage: language,
+            }),
+          }
+        );
+        const translated = await res.json();
+        setPageContent(translated);
+      } catch (err) {
+        console.error("Translation fetch error:", err);
       }
     };
 
     fetchCategories();
-    if (language !== 'en') {
-      fetchPageContent();
-    }
+    fetchStaticCopy();
   }, [language]);
 
-  const [svgContent, setSvgContent] = useState(""); // State to hold SVG content
-  const svgContainerRef = useRef(null);
-  const scrollContainerRef = useRef(null);
-  const pathRef = useRef(null);
-
-  useEffect(() => {
-    // if (!metaFields) return; // Ensure animation doesn't run until metaFields are set
-
-    const path = pathRef.current;
-    if (!path) return;
-
-    const pathLength = path.getTotalLength(); // Get the total length of the path
-
-    const handleOffset = (mPercent) => {
-      const distance = window.scrollY;
-      const totalDistance = document.body.scrollHeight - window.innerHeight;
-      const percentage = typeof mPercent === "number" ? mPercent : distance / totalDistance;
-
-      // Clamp percentage value to ensure it doesn't exceed [0, 1] range
-      const clampedPercentage = Math.min(Math.max(percentage, 0), 1);
-
-      // Update the strokeDasharray and strokeDashoffset values
-      const offset = pathLength - (pathLength * clampedPercentage * 0.5); // Adjust for desired speed
-
-      path.style.strokeDasharray = pathLength;
-      path.style.strokeDashoffset = offset;
-    };
-
-    window.addEventListener("scroll", () => handleOffset());
-    
-    // Trigger initially
-    handleOffset(0);
-
-    return () => {
-      window.removeEventListener("scroll", () => handleOffset());
-    };
-  }, []); // Run this effect only when `metaFields` is set
-
-  // width="2100" height="4026" viewBox="110 0 2436 5026"
-  const [viewBox, setViewBox] = useState("110 0 2436 5026");
-  const [width, setWidth] = useState("2100");
-  const [height, setHeight] = useState("4026");
-
-  useEffect(() => {
-    const updateSVGSize = () => {
-        if (window.innerWidth <= 768) {
-          setViewBox("450 0 900 2790");
-          setWidth("900");
-          setHeight("5700");
-        } else {
-            setViewBox("110 0 2436 5026");
-            setWidth("2100");
-            setHeight("4026");
-        }
-    };
-
-    updateSVGSize(); // Initial check
-    window.addEventListener('resize', updateSVGSize);
-
-    return () => window.removeEventListener('resize', updateSVGSize);
-  }, []);
-
+  /* ────────────────────────────
+     3. RENDER
+  ──────────────────────────── */
   return (
-    <div className="scrollContainer w-full lg:h-[3080px] h-[5800px] md:h-[5300px] overflow-hidden bg-no-repeat" ref={svgContainerRef}>
-      <svg 
-        width={width}
-        height={height}
-        viewBox={viewBox}
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg">
-          <path 
-            strokeOpacity="0.55"
-            strokeWidth="21"
-            speed="2"
-            stay=".7"
-            className="scrollPath cls-3"
-            style={{ strokeDasharray: "80000", zIndex: 5 }}
-            ref={pathRef}
-            stroke-width="80"          
-          d="M445.634 0.836114C454.975 -1.82847 462.56 2.21838 469.367 8.13043C488.641 24.884 511.766 69.8656 532.391 93.0475C808.928 403.971 1393.2 266.645 1760.87 255.937C1957.97 250.208 2318.88 285.83 2398.03 500.613C2406.61 523.911 2419.87 566.328 2410.06 589.326C2407.31 595.771 2399.84 599.652 2398.47 606.929C2397.1 614.207 2401.51 621.118 2401.51 628.562C2401.53 654.226 2360.77 702.521 2341.34 719.775C2184.33 859.232 1792.34 817.831 1592.58 812.286C1380.58 806.39 1169.45 800.978 956.952 796.565C710.279 791.435 294.654 755.18 117.475 962.668C-11.1398 1113.28 134.097 1314.31 285.465 1378.99C826.614 1610.25 1464.22 1200.98 2032.37 1356.91C2271.61 1422.56 2502.59 1627.33 2418.27 1895.62C2349.03 2115.92 2079.59 2213.46 1870.2 2250.3C1528.13 2310.47 1181.17 2264.73 837.306 2260.74C654.671 2258.61 378.337 2262.02 234.131 2385.51C78.438 2518.84 193.995 2674.38 343.86 2741.06C576.428 2844.55 976.073 2806.36 1232.76 2801.4C1489.45 2796.44 1899.47 2756.93 2141.8 2857.32C2448.08 2984.21 2356.99 3259.64 2114.91 3396.55C1545.75 3718.43 613.894 3033.77 132.205 3621.51C41.5291 3732.16 30.3467 3842.82 69.671 3977.2C141.546 4222.79 450.178 4339 679.908 4388.86C1123.1 4485.07 1685.04 4433.97 2044.71 4743.7C2104.27 4794.99 2165.43 4866.4 2185.63 4943.61C2191.21 4964.89 2204.38 5017.33 2174.44 5025.38C2143.46 5033.71 2136.19 4956.02 2129.06 4935.47C2068.27 4760.15 1824.82 4643.28 1657.34 4591.8C1240.99 4463.85 771.056 4519.94 369.789 4336.63C116.546 4220.94 -85.5317 3988.7 36.5798 3699.86C161.833 3403.65 512.729 3315.31 811.343 3325.52C1212.8 3339.23 1754.55 3559.52 2122.15 3339.78C2188.3 3300.24 2217.76 3276.09 2253.78 3207.42C2392.19 2943.5 2080.01 2861.6 1880.89 2846.06C1522.9 2818.1 1162.69 2855.54 804.84 2855.76C593.995 2855.89 254.924 2836.37 139.198 2629.57C12.8129 2403.71 302.83 2262.97 484.739 2233.04C810.347 2179.45 1163.93 2251.18 1495.31 2241.84C1754.18 2234.54 2212.41 2191.88 2354.27 1944.4C2472.83 1737.56 2354.01 1568.78 2170.8 1463.38C1858.02 1283.45 1393.61 1404.67 1056.55 1460.51C743.387 1512.41 315.161 1552.76 95.0933 1275.79C11.7318 1170.87 -19.9067 1071.12 64.6204 952.11C232.12 716.277 689.924 738.477 947.492 745.155C1247.69 752.932 1548.2 771.701 1848.66 773.932C1986.88 774.965 2237.93 777.746 2333.07 660.488C2340.04 651.894 2366.63 610.693 2368.22 602.183C2369.54 595.139 2363.4 552.622 2361.48 543.079C2333.61 404.904 2155.25 344.001 2031.73 321.552C1547 233.504 862.644 532.338 486.985 112.232C471.884 95.3457 428.928 42.7367 430.381 21.2368C430.82 14.692 439.249 2.63474 445.6 0.819495L445.634 0.836114Z" 
-          fill="url(#paint0_angular_2834_3931)
-          "/>
-      <defs>
-      <radialGradient id="paint0_angular_2834_3931" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1218.59 2337.99) rotate(-90) scale(2962 3004.37)">
-      <stop offset="0.06" stop-color="#9D2924"/>
-      <stop offset="0.265" stop-color="#EA5C50"/>
-      <stop offset="0.515" stop-color="#E4A16B"/>
-      <stop offset="0.76" stop-color="#80B2BD"/>
-      <stop offset="0.96" stop-color="#D88BD3"/>
-      </radialGradient>
-      </defs>
-      </svg>
-      <div className="absolute w-full h-full top-[0] z-10 ">
-        <div className='w-full bg-cover bg-center relative'>
-          <div className='h-[50vh] sm:h-[50vh] md:h-[60vh] lg:h-[80dvh] w-full bg-cover bg-center relative'>
-            <img 
-              src="/images/productListing.png" 
-              className='hidden sm:hidden md:block w-full h-[65dvh] object-cover' 
-              alt="Large Image"
-            />
-            <img 
-              src="/images/productListingSmall.png" 
-              className='block sm:block md:hidden w-full h-full object-cover' 
-              alt="Small Image"
-            />
+    <div className="w-full relative min-h-screen bg-white">
+      {/* ── HERO BANNER ───────────────────────── */}
+      <div className="h-[50vh] md:h-[60vh] lg:h-[80dvh] relative w-full">
+        {/* Desktop banner */}
+        <img
+          src="/images/productListing.png"
+          alt="Product banner"
+          className="hidden md:block w-full h-[65dvh] object-cover"
+        />
+        {/* Mobile banner */}
+        <img
+          src="/images/productListingSmall.png"
+          alt="Product banner mobile"
+          className="block md:hidden w-full h-full object-cover"
+        />
 
-            <div className='absolute inset-3 flex flex-col gap-3 sm:gap-4 md:gap-5 lg:gap-6 justify-center text-white font-medium p-5 xl:p-10 -mb-40 sm:-mb-44 md:-mb-64 lg:-mb-16'>
-              <p className="text-[12px] sm:text-[14px] md:text-[15px] lg:text-[16px] font-normal">{pageContent.sectionTitle}</p>
-              <h1 className='w-full md:w-[500px] lg:w-[650px] text-[40px] sm:text-[32px] md:text-[40px] lg:text-[56px] leading-[45px] sm:leading-10 md:leading-10 lg:leading-[65px] font-heading'>
-                {pageContent.mainHeading}
-              </h1>
-            </div>
-          </div>
-          
-          <div className="bg-white">
-            {categories.map((category, index) => (
-              <div key={index}>
-                {/* <h2>{category.categoryName}</h2> */}
-                <ProductListingCards3 products={category.products} language={language}/>
-              </div>
-            ))}
-          </div>
-          {/* <OurGlobalPresence language={language}/> */}
+        <div className="absolute inset-4 md:inset-6 lg:inset-10 flex flex-col justify-center gap-4 md:gap-5 lg:gap-6 text-white">
+          <p className="text-xs md:text-sm lg:text-base font-normal">
+            {pageContent.sectionTitle}
+          </p>
+          <h1 className="font-heading text-3xl md:text-4xl lg:text-5xl leading-tight lg:leading-[65px] max-w-[650px]">
+            {pageContent.mainHeading}
+          </h1>
         </div>
-      </div>      
+      </div>
+
+      {/* ── PRODUCT LIST ───────────────────────── */}
+      <div className="bg-white">
+        {categories.map((cat, idx) => (
+          <div key={idx}>
+            <ProductListingCards3 products={cat.products} language={language} />
+          </div>
+        ))}
+      </div>
+
+      {/* ── OPTIONAL GLOBAL PRESENCE ───────────── */}
+      {/* <OurGlobalPresence language={language} /> */}
+
+      {/* ── FOOTER ─────────────────────────────── */}
+      <Footer language={language} />
     </div>
-    
   );
 };
 


### PR DESCRIPTION
feat(frontend): remove SVG-scroll animation and fixed-height scaffolding from product-listing pages

## Issue
The animated, diagonal SVG “path” added thousands of unnecessary DOM nodes, large inline gradients, and brittle fixed heights (`h-[…px]`). This caused:
1. **Layout inflexibility** – pages needed hard-coded `h-[4600px]` / `h-[5300px]`, leading to blank areas or footer overlap.
2. **Performance overhead** – large blurred SVG + scroll listener on every product-listing page.
3. **Maintenance pain** – duplicated animation logic across **ProductListing**, **ProductListing2**, and **ProductListing3**.

## What Changed
| Area | Change |
|------|--------|
| **Imports** | Removed `useRef`, scroll-animation state, and SVG helper refs; dropped `OurGlobalPresence` placeholder import (still commented but inert). | | **State & Effects** | Deleted all `svgContent`, `pathRef`, `svgContainerRef`, related `useEffect` blocks (scroll listeners, resize handlers). | | **JSX** | Stripped `<svg>…</svg>` wrapper and the outer *scrollContainer* with fixed heights; replaced top-level wrapper with `w-full relative min-h-screen bg-white`. | | **Hero banner** | Now sits directly in normal flow; no absolute overlay wrapper needed for content after hero. | | **Footer** | Added back in **ProductListing3** and ensured placement below content in **ProductListing** (was commented). |

## Files Changed
- `src/pages/ProductListing.tsx`
- `src/pages/ProductListing2.tsx`
- `src/pages/ProductListing3.tsx`

## Why This Change
Removing the decorative SVG animation:
- **Eliminates layout bugs** (white gaps / content clipping on various devices).
- **Improves first paint & scroll performance** (lighter DOM, no per-frame dashOffset updates).
- **Reduces code duplication** and makes the listing pages easier to maintain. The UI and marketing copy remain identical; only the background flourish was removed.